### PR TITLE
Fix 403 errors from tornado.access when handling new WebSocket connections

### DIFF
--- a/omnibus/factories.py
+++ b/omnibus/factories.py
@@ -33,6 +33,9 @@ def websocket_connection_factory(auth_class, pubsub_instance):
         authenticator_class = auth_class
         pubsub = pubsub_instance
 
+        def check_origin(self, origin):
+            return True
+
         def open(self):
             self.on_open(None)
 


### PR DESCRIPTION
I think an update to python-tornado (I'm on 4.0.2) breaks incoming WebSocket connections in Omnibus.  In Googling around, the common answer is to simply add a check_origin method that returns True.  This mimics the behavior tornado used to have and allows the WebSocket connections gracefully.

Before this commit, these messages would be displayed from omnibusd:

```
$ ./manage.py omnibusd
WARNING:tornado.access:403 GET /ec (127.0.0.1) 0.90ms
WARNING:tornado.access:403 GET /ec (127.0.0.1) 0.69ms
WARNING:tornado.access:403 GET /ec (127.0.0.1) 0.51ms
WARNING:tornado.access:403 GET /ec (127.0.0.1) 0.58ms
WARNING:tornado.access:403 GET /ec (127.0.0.1) 0.59ms
WARNING:tornado.access:403 GET /ec (127.0.0.1) 1.05ms
WARNING:tornado.access:403 GET /ec (127.0.0.1) 1.05ms
WARNING:tornado.access:403 GET /ec (127.0.0.1) 0.63ms
```

Some references:
https://github.com/mopidy/mopidy/issues/788
http://stackoverflow.com/questions/24851207/tornado-403-get-warning-when-opening-websocket
http://stackoverflow.com/questions/25177147/tornadio2-failed-error-during-websocket-handshake-unexpected-response-code
